### PR TITLE
Add support to Watch all object types 

### DIFF
--- a/authzed/api/v1/watch_service.proto
+++ b/authzed/api/v1/watch_service.proto
@@ -22,14 +22,15 @@ service WatchService {
 // watching mutations, and an optional start snapshot for when to start
 // watching.
 message WatchRequest {
-  repeated string object_types = 1 [
-    (validate.rules).repeated .min_items = 1,
+  repeated string optional_object_types = 1 [
+    (validate.rules).repeated .min_items = 0,
     (validate.rules).repeated .items.string = {
       pattern : "^([a-z][a-z0-9_]{2,62}[a-z0-9]/"
                 ")?[a-z][a-z0-9_]{2,62}[a-z0-9]$",
       max_bytes : 128,
     }
   ];
+
   ZedToken optional_start_cursor = 2;
 }
 


### PR DESCRIPTION
The changes herein add support to the v1.WatchService.Watch API that allows for a client to watch for changes optionally filtered by one or more object types. If the `optional_object_types` field is not specified by the client then the intention is to start a watch over all object types.

These changes are to support the work that in underway in https://github.com/authzed/spicedb/pull/255 and https://github.com/authzed/spicedb/pull/263 and as proposed in the new LookupWatch API that is under active discussion and development in https://github.com/authzed/spicedb/issues/207.

I recognize these changes are breaking, so I'm open to alternatives, but seeing as there is not yet a v1.WatchService.Watch API implementation (it is under active PR as referenced above) I don't these these breaking changes are impacting clients. Thoughts or alternative suggestions are welcomed 👍 

In particular I would like @josephschorr to take a look over these changes and give me any feedback he may have.