### PR TITLE
Fix documentation of DeleteRelationships

### DIFF
--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -33,8 +33,9 @@ service PermissionsService {
       };
     }
 
-  // DeleteRelationships atomically bulk deletes relationships matching one or
-  // more filters. An optional set of preconditions can be provided that must
+  // DeleteRelationships atomically bulk deletes all relationships matching the
+  // provided filter. If no relationships match, none will be deleted and the
+  // operation will succeed. An optional set of preconditions can be provided that must
   // be satisfied for the operation to commit.
   rpc DeleteRelationships(DeleteRelationshipsRequest)
     returns (DeleteRelationshipsResponse) {


### PR DESCRIPTION
## Motivation
The previous wording ("one or more filters") made it sound like `relationship_filter` should have been `repeeated`, but that's not the way the service is implemented. The new wording more closely reflects the behavior of the endpoint.

## Changes
Documentation wording

## Testing
Review.