### PR TITLE
introduce caveat in API

### DIFF
--- a/authzed/api/v1/core.proto
+++ b/authzed/api/v1/core.proto
@@ -4,6 +4,7 @@ package authzed.api.v1;
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
 
+import "google/protobuf/struct.proto";
 import "validate/validate.proto";
 
 // Relationship specifies how a resource relates to a subject. Relationships
@@ -21,6 +22,25 @@ message Relationship {
 
   // subject is the subject to which the resource is related, in some manner.
   SubjectReference subject = 3 [ (validate.rules).message.required = true ];
+
+  // optional_caveat is a reference to a the caveat that must be enforced over the relationship
+  ContextualizedCaveat optional_caveat = 4 [ (validate.rules).message.required = false ];
+}
+
+/**
+ * ContextualizedCaveat represents a reference to a caveat to be used by caveated relationships.
+ * The context consists of key-value pairs that will be injected at evaluation time.
+ * The keys must match the arguments defined on the caveat in the schema.
+ */
+message ContextualizedCaveat {
+  /** caveat_name is the name of the caveat expression to use, as defined in the schema **/
+  string caveat_name = 1 [ (validate.rules).string = {
+    pattern : "^([a-zA-Z0-9_][a-zA-Z0-9/_|-]{0,127})$",
+    max_bytes : 128,
+  } ];
+
+  /** context consists of any named values that are defined at write time for the caveat expression **/
+  google.protobuf.Struct context = 2 [ (validate.rules).message.required = false ];
 }
 
 // SubjectReference is used for referring to the subject portion of a


### PR DESCRIPTION
Part of https://github.com/authzed/spicedb/issues/836

`Relationships` can be caveated through a `ContextualizedCaveat`. This is a reference to the identifier of a caveat, and a caveat context, which is a key-value structure fed into the caveat evaluation engine.