### PR TITLE
introduce caveat context in PermissionService

### DIFF
--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -4,6 +4,7 @@ package authzed.api.v1;
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
 
+import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";
 import "validate/validate.proto";
 
@@ -250,6 +251,17 @@ message CheckPermissionRequest {
 
   // subject is the subject that will be checked for the permission or relation.
   SubjectReference subject = 4 [ (validate.rules).message.required = true ];
+
+  /** context consists of named values that are injected into the caveat evaluation context **/
+  google.protobuf.Struct context = 5 [ (validate.rules).message.required = false ];
+}
+
+// PartialCaveatInfo carries information necessary for the client to take action
+// in the event a response contains a partially evaluated caveat
+message PartialCaveatInfo {
+  // missing_required_context is a list of one or more fields that were missing and prevented caveats
+  // from being fully evaluated
+  repeated string missing_required_context = 1 [(validate.rules).repeated.min_items = 1];
 }
 
 message CheckPermissionResponse {
@@ -257,6 +269,7 @@ message CheckPermissionResponse {
     PERMISSIONSHIP_UNSPECIFIED = 0;
     PERMISSIONSHIP_NO_PERMISSION = 1;
     PERMISSIONSHIP_HAS_PERMISSION = 2;
+    PERMISSIONSHIP_CONDITIONAL_PERMISSION = 4;
   }
 
   ZedToken checked_at = 1;
@@ -270,6 +283,9 @@ message CheckPermissionResponse {
   // exists a relationship with the requested relation from the given resource
   // to the given subject.
   Permissionship permissionship = 2;
+
+  // partial_caveat_info hods information of a partially-evaluated caveated response
+  PartialCaveatInfo partial_caveat_info = 3 [ (validate.rules).message.required = false ];
 }
 
 // ExpandPermissionTreeRequest returns a tree representing the expansion of all
@@ -324,6 +340,16 @@ message LookupResourcesRequest {
 
   // subject is the subject with access to the resources.
   SubjectReference subject = 4 [ (validate.rules).message.required = true ];
+
+  /** context consists of named values that are injected into the caveat evaluation context **/
+  google.protobuf.Struct context = 5 [ (validate.rules).message.required = false ];
+}
+
+// LookupPermissionship represents whether a Lookup response was partially evaluated or not
+enum LookupPermissionship {
+  LOOKUP_PERMISSIONSHIP_UNSPECIFIED = 0;
+  LOOKUP_PERMISSIONSHIP_HAS_PERMISSION = 1;
+  LOOKUP_PERMISSIONSHIP_CONDITIONAL_PERMISSION = 2;
 }
 
 // LookupResourcesResponse contains a single matching resource object ID for the
@@ -331,6 +357,12 @@ message LookupResourcesRequest {
 message LookupResourcesResponse {
   ZedToken looked_up_at = 1;
   string resource_object_id = 2;
+
+  // permissionship indicates whether the response was partially evaluated or not
+  LookupPermissionship permissionship = 3 [ (validate.rules).enum.defined_only = true ];
+
+  // partial_caveat_info hods information of a partially-evaluated caveated response
+  PartialCaveatInfo partial_caveat_info = 4  [ (validate.rules).message.required = false ];
 }
 
 // LookupSubjectsRequest performs a lookup of all subjects of a particular
@@ -362,6 +394,9 @@ message LookupSubjectsRequest {
     pattern : "^([a-z][a-z0-9_]{1,62}[a-z0-9])?$",
     max_bytes : 64,
   } ];
+
+  /** context consists of named values that are injected into the caveat evaluation context **/
+  google.protobuf.Struct context = 6 [ (validate.rules).message.required = false ];
 }
 
 // LookupSubjectsResponse contains a single matching subject object ID for the
@@ -377,4 +412,10 @@ message LookupSubjectsResponse {
   // will only contain object IDs if `subject_object_id` is a wildcard (`*`) and
   // will only be populated if exclusions exist from the wildcard.
   repeated string excluded_subject_ids = 3;
+
+  // permissionship indicates whether the response was partially evaluated or not
+  LookupPermissionship permissionship = 4 [ (validate.rules).enum.defined_only = true ];
+
+  // partial_caveat_info hods information of a partially-evaluated caveated response
+  PartialCaveatInfo partial_caveat_info = 5 [ (validate.rules).message.required = false ];
 }


### PR DESCRIPTION
Part of https://github.com/authzed/spicedb/issues/881
Part of https://github.com/authzed/spicedb/issues/882
Part of https://github.com/authzed/spicedb/issues/880

this makes it possible for clients to provide context for caveat evaluation at request time.
This context will be injected at evaluation time and influence the evaluation result.