### PR TITLE
Add an error reason for caveat parameter type errors

### DIFF
--- a/authzed/api/v1/error_reason.proto
+++ b/authzed/api/v1/error_reason.proto
@@ -134,9 +134,26 @@ enum ErrorReason {
   //     { "reason": "ERROR_REASON_INVALID_SUBJECT_TYPE",
   //       "domain": "authzed.com",
   //       "metadata": {
+  //         "definition_name": "somedefinition",
   //         "relation_name": "somerelation",
   //         "subject_type": "user:*"
   //       }
   //     }
   ERROR_REASON_INVALID_SUBJECT_TYPE = 10;
+
+  // The request tries to specify a caveat parameter value with the wrong type.
+  //
+  // Example of an ErrorInfo:
+  //
+  //     { "reason": "ERROR_REASON_CAVEAT_PARAMETER_TYPE_ERROR",
+  //       "domain": "authzed.com",
+  //       "metadata": {
+  //         "definition_name": "somedefinition",
+  //         "relation_name": "somerelation",
+  //         "caveat_name": "somecaveat",
+  //         "parameter_name": "someparameter",
+  //         "expected_type": "int",
+  //       }
+  //     }
+  ERROR_REASON_CAVEAT_PARAMETER_TYPE_ERROR = 11;
 }


### PR DESCRIPTION
Will be used if the client sends a parameter value for a caveat that cannot be converted to the expected type