### PR TITLE
buf: push everything but releases as drafts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,3 +31,4 @@ jobs:
         if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
         with:
           buf_token: "${{ secrets.BUF_REGISTRY_TOKEN }}"
+          draft: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,18 @@
+---
+name: "Release"
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - "*"
+jobs:
+  buf:
+    name: "Push BSR tag"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: "bufbuild/buf-setup-action@v1"
+        with:
+          version: "1.4.0"
+      - uses: "bufbuild/buf-push-action@v1"
+        with:
+          buf_token: "${{ secrets.BUF_REGISTRY_TOKEN }}"


### PR DESCRIPTION
I need to test this, but the idea is that every commit gets push as a draft and only releases will be published as tags, which move forward the documentation etc...