### PR TITLE
.github: explicitly name draft

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,4 +31,4 @@ jobs:
         if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
         with:
           buf_token: "${{ secrets.BUF_REGISTRY_TOKEN }}"
-          draft: true
+          draft: "${{ github.sha }}"


### PR DESCRIPTION
This defaults to the ref (e.g. "main").
"main" is explicitly not allowed by drafts.