### PR TITLE
.github: manually buf push

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,8 +27,9 @@ jobs:
         with:
           against: "https://github.com/authzed/api.git#branch=main"
           buf_token: "${{ secrets.BUF_REGISTRY_TOKEN }}"
-      - uses: "bufbuild/buf-push-action@v1"
+      - name: "Push to BSR"
         if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
-        with:
-          buf_token: "${{ secrets.BUF_REGISTRY_TOKEN }}"
-          draft: "${{ github.sha }}"
+        shell: "bash"
+        env:
+          BUF_TOKEN: "${{ secrets.BUF_REGISTRY_TOKEN }}"
+        run: "buf push --draft ${{ github.sha }}"


### PR DESCRIPTION
The buf push action only uses github.ref_name and no sha for drafts, which is incompatible with pushing things from main.