### PR TITLE
remove max value on LR optional limit

### DIFF
--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -391,7 +391,7 @@ message LookupResourcesRequest {
   // before the stream is closed on the server side. By default, the stream will continue
   // resolving resources until exhausted or the stream is closed due to the client or a
   // network issue.
-  uint32 optional_limit = 6 [(validate.rules).uint32 = {gte:0, lte: 1000}];
+  uint32 optional_limit = 6 [(validate.rules).uint32 = {gte:0}];
 
   // optional_cursor, if specified, indicates the cursor after which results should resume being returned.
   // The cursor can be found on the LookupResourcesResponse object.


### PR DESCRIPTION
The limit is already optional so capping it at 1000 is counterintuitive. We can add flags to set/validate a max value in spicedb at runtime that users can configure.