### PR TITLE
add serialization error

### DIFF
--- a/authzed/api/v1/error_reason.proto
+++ b/authzed/api/v1/error_reason.proto
@@ -285,4 +285,18 @@ enum ErrorReason {
   //       }
   //     }
   ERROR_REASON_MAXIMUM_DEPTH_EXCEEDED = 19;
+
+  // The request failed due to a serialization error in the backend database.
+  // This typically indicates that various in flight transactions conflicted with each other
+  // and the database had to abort one or more of them. SpiceDB will retry a few times before returning
+  // the error to the client.
+  //
+  // Example of an ErrorInfo:
+  //
+  //     {
+  //       "reason": "ERROR_REASON_SERIALIZATION_FAILURE",
+  //       "domain": "authzed.com",
+  //       "metadata": {}
+  //     }
+  ERROR_REASON_SERIALIZATION_FAILURE = 20;
 }


### PR DESCRIPTION
to support https://github.com/authzed/spicedb/pull/1552

Database serialization errors are not that uncommon when running the backend datastores at isolation level `SERIALIZABLE`. However, those errors could be reported in a clearer way to the client instead of some cryptic database error.

This adds a new error reason to support providing a typed response when serialization errors happen.