### PR TITLE
fix buf push tag on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,9 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "bufbuild/buf-setup-action@v1"
         with:
-          version: "1.22.0"
-      - uses: "bufbuild/buf-push-action@v1"
-        with:
-          buf_token: "${{ secrets.BUF_REGISTRY_TOKEN }}"
+          version: "1.30.0"
+      - name: "push release name to BSR"
+        run:
+          "buf push --tag ${{ github.ref_name }}"
+        env:
+          BUF_TOKEN: "${{ secrets.BUF_REGISTRY_TOKEN }}"


### PR DESCRIPTION
the buf github action does not support
configuring the tag to be pushed, so it
always defaults to pushing the github SHA.

This changes the action to push the tag
to BSR with the ref_name instead of the commit
SHA.

see https://github.com/authzed/api/actions/runs/8331581711/job/22798794304

Also see https://github.com/bufbuild/buf-push-action/issues/20#issuecomment-1944362672 for future changes on this topic, the buf team will be introducing some changes to help here