### PR TITLE
generate multiple java files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,14 +10,14 @@ on:
       - "*"
 jobs:
   lint:
-    name: "Lint"
+    name: "Lint & Publish Draft/Branch"
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "authzed/actions/yaml-lint@main"
-      - uses: "bufbuild/buf-setup-action@v1"
+      - uses: "bufbuild/buf-setup-action@v1.30.0"
         with:
-          version: "1.22.0"
+          version: "1.30.0"
       - uses: "bufbuild/buf-lint-action@v1"
       - uses: "bufbuild/buf-breaking-action@v1"
         if: "github.event_name == 'pull_request'"
@@ -33,3 +33,15 @@ jobs:
         env:
           BUF_TOKEN: "${{ secrets.BUF_REGISTRY_TOKEN }}"
         run: "buf push --draft ${{ github.sha }}"
+      - name: "Push to BSR a Draft"
+        if: "github.event_name == 'push' && github.ref == 'refs/heads/main'"
+        shell: "bash"
+        env:
+          BUF_TOKEN: "${{ secrets.BUF_REGISTRY_TOKEN }}"
+        run: "buf push --draft ${{ github.sha }}"
+      - name: "Push to BSR a Branch"
+        if: "github.event_name == 'push' && github.ref != 'refs/heads/main'"
+        shell: "bash"
+        env:
+          BUF_TOKEN: "${{ secrets.BUF_REGISTRY_TOKEN }}"
+        run: "buf push --branch ${{ github.sha }}"

--- a/authzed/api/v1/core.proto
+++ b/authzed/api/v1/core.proto
@@ -3,6 +3,7 @@ package authzed.api.v1;
 
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
+option java_multiple_files = true;
 
 import "google/protobuf/struct.proto";
 import "validate/validate.proto";

--- a/authzed/api/v1/debug.proto
+++ b/authzed/api/v1/debug.proto
@@ -8,6 +8,7 @@ import "google/protobuf/duration.proto";
 
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
+option java_multiple_files = true;
 
 // DebugInformation defines debug information returned by an API call in a footer when
 // requested with a specific debugging header.

--- a/authzed/api/v1/error_reason.proto
+++ b/authzed/api/v1/error_reason.proto
@@ -3,6 +3,7 @@ package authzed.api.v1;
 
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
+option java_multiple_files = true;
 
 // Defines the supported values for `google.rpc.ErrorInfo.reason` for the
 // `authzed.com` error domain.

--- a/authzed/api/v1/experimental_service.proto
+++ b/authzed/api/v1/experimental_service.proto
@@ -3,6 +3,7 @@ package authzed.api.v1;
 
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
+option java_multiple_files = true;
 
 import "google/api/annotations.proto";
 import "validate/validate.proto";

--- a/authzed/api/v1/openapi.proto
+++ b/authzed/api/v1/openapi.proto
@@ -3,6 +3,7 @@ package authzed.api.v1;
 
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
+option java_multiple_files = true;
 
 import "protoc-gen-openapiv2/options/annotations.proto";
 

--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -3,6 +3,7 @@ package authzed.api.v1;
 
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
+option java_multiple_files = true;
 
 import "google/protobuf/struct.proto";
 import "google/api/annotations.proto";

--- a/authzed/api/v1/schema_service.proto
+++ b/authzed/api/v1/schema_service.proto
@@ -3,6 +3,7 @@ package authzed.api.v1;
 
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
+option java_multiple_files = true;
 
 import "google/api/annotations.proto";
 import "validate/validate.proto";

--- a/authzed/api/v1/watch_service.proto
+++ b/authzed/api/v1/watch_service.proto
@@ -3,6 +3,7 @@ package authzed.api.v1;
 
 option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
 option java_package = "com.authzed.api.v1";
+option java_multiple_files = true;
 
 import "google/api/annotations.proto";
 import "validate/validate.proto";

--- a/buf.yaml
+++ b/buf.yaml
@@ -8,3 +8,6 @@ deps:
 lint:
   ignore:
     - "authzed/api/v0"  # legacy from before we used buf
+breaking:
+  use:
+    - "WIRE_JSON"


### PR DESCRIPTION
Fixes https://github.com/authzed/authzed-java/issues/80

# ⚠️ This is a breaking change for authzed-java ⚠️ 

Tweaks the proto java output to have more ergonomic class names.
As a consequence, all types become top-level classes without nested outer classes.

E.g. `ExperimentalServiceOuterClass.BulkImportRelationshipsResponse` becomes `BulkImportRelationshipsResponse`

The generated output proto is less verbose, but clients will have to update their code accordingly. Given that the `authzed-java` SDK is < 1.0.0, we consider the API surface unstable and will proceed with the change.

>From https://protobuf.dev/reference/java/java-generated/#invocation When the option java_multiple_files = true is enabled, Then the compiler will also create separate .java files for each of the classes/enums which it will generate for each top-level message, enumeration, and service declared in the .proto file.

>The goal is to have this option stop generating "OuterClass" named classes for better ergonomics.

## Improvements to Buf CI

The PR also changes how branches are made available. The `buf` GitHub Action is updated to the latest version which supports `bug push --branch` command. The branch will be pushed as a branch to BSR on every commit, and only as a draft when merged into `main`.

## ⚠️ API breakage linter has been temporarily disabled

Rollback https://github.com/authzed/api/pull/97/commits/7a8b8183e50febeb5d1651380331c35ee28a19f9 once these changes have been published
