### PR TITLE
Increase upper limit for ReadRelationships, LookupResources, and DeleteRelationships API

### DIFF
--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -212,7 +212,7 @@ message ReadRelationshipsRequest {
   // before the stream is closed on the server side. By default, the stream will continue
   // resolving relationships until exhausted or the stream is closed due to the client or a
   // network issue.
-  uint32 optional_limit = 3 [(validate.rules).uint32 = {gte:0, lte: 1000}];
+  uint32 optional_limit = 3 [(validate.rules).uint32 = {gte:0, lte: 10000}];
 
   // optional_cursor, if specified, indicates the cursor after which results should resume being returned.
   // The cursor can be found on the ReadRelationshipsResponse object.
@@ -286,7 +286,7 @@ message DeleteRelationshipsRequest {
   // the deletion call will fail with an error to prevent partial deletion. If partial deletion
   // is needed, specify below that partial deletion is allowed. Partial deletions can be used
   // in a loop to delete large amounts of relationships in a *non-transactional* manner.
-  uint32 optional_limit = 3 [(validate.rules).uint32 = {gte:0, lte: 1000}];
+  uint32 optional_limit = 3 [(validate.rules).uint32 = {gte:0, lte: 10000}];
 
   // optional_allow_partial_deletions, if true and a limit is specified, will delete matching found
   // relationships up to the count specified in optional_limit, and no more.
@@ -473,7 +473,7 @@ message LookupResourcesRequest {
   // before the stream is closed on the server side. By default, the stream will continue
   // resolving resources until exhausted or the stream is closed due to the client or a
   // network issue.
-  uint32 optional_limit = 6 [(validate.rules).uint32 = {gte:0, lte: 1000}];
+  uint32 optional_limit = 6 [(validate.rules).uint32 = {gte:0, lte: 10000}];
 
   // optional_cursor, if specified, indicates the cursor after which results should resume being returned.
   // The cursor can be found on the LookupResourcesResponse object.


### PR DESCRIPTION
Currently the API limits for these requests are set to 1,000 which can make deleting/reading millions of relationships take quite a long time. This PR increased the limit to 10,000. This limit should still protect the underlying datastore while allowing for more flexibility.