### PR TITLE
Optionally return status on WriteRelationships

### DIFF
--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -265,9 +265,27 @@ message WriteRelationshipsRequest {
   repeated Precondition optional_preconditions = 2
       [ (validate.rules).repeated .items.message.required =
             true ]; // To be bounded by configuration
+
+  bool with_status = 3;
 }
 
-message WriteRelationshipsResponse { ZedToken written_at = 1; }
+message RelationshipUpdateStatus {
+  enum Status {
+    STATUS_UNSPECIFIED = 0;
+    STATUS_CREATED = 1;
+    STATUS_ALREADY_EXISTED = 2;
+    STATUS_DELETED = 3;
+    STATUS_DIDNT_EXIST = 4;
+  }
+
+  Status status = 1;
+  Relationship relationship = 2;
+}
+
+message WriteRelationshipsResponse {
+  ZedToken written_at = 1;
+  repeated RelationshipUpdateStatus update_statuses = 2;
+}
 
 // DeleteRelationshipsRequest specifies which Relationships should be deleted,
 // requesting the delete of *ALL* relationships that match the specified

--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -270,21 +270,22 @@ message WriteRelationshipsRequest {
 }
 
 message RelationshipUpdateStatus {
-  enum Status {
-    STATUS_UNSPECIFIED = 0;
-    STATUS_CREATED = 1;
-    STATUS_ALREADY_EXISTED = 2;
-    STATUS_DELETED = 3;
-    STATUS_DIDNT_EXIST = 4;
+  message Update {
+    Relationship old = 1;
+    Relationship new = 2;
   }
 
-  Status status = 1;
-  Relationship relationship = 2;
+  oneof status {
+    Relationship noop = 1;
+    Relationship created = 2;
+    Relationship deleted = 3;
+    Update updated = 4;
+  }
 }
 
 message WriteRelationshipsResponse {
   ZedToken written_at = 1;
-  repeated RelationshipUpdateStatus update_statuses = 2;
+  repeated RelationshipUpdateStatus updates = 2;
 }
 
 // DeleteRelationshipsRequest specifies which Relationships should be deleted,

--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -266,25 +266,38 @@ message WriteRelationshipsRequest {
       [ (validate.rules).repeated .items.message.required =
             true ]; // To be bounded by configuration
 
+  // with_status, if true, indicates that the response should include the status of each update.
+  // This can be useful for knowing how to rollback a given call to WriteRelationships, but adds a small amount
+  // of compute overhead to the request.
   bool with_status = 3;
 }
 
+// RelationshipUpdateStatus is the status of a relationship update.
 message RelationshipUpdateStatus {
   message Update {
+    // old is the previous relationship.
     Relationship old = 1;
+    // new is the new relationship.
     Relationship new = 2;
   }
 
   oneof status {
-    Relationship noop = 1;
+    // no_op indicates that the relationship was not changed (already existed on TOUCH, or didn't exist on DELETE).
+    Relationship no_op = 1;
+    // created indicates that the relationship was created.
     Relationship created = 2;
+    // deleted indicates that the relationship was deleted.
     Relationship deleted = 3;
+    // updated indicates that the relationship was updated.
     Update updated = 4;
   }
 }
 
 message WriteRelationshipsResponse {
+  // written_at is the revision at which the relationships were written.
   ZedToken written_at = 1;
+
+  // updates is the status of each relationship update, if requested.
   repeated RelationshipUpdateStatus updates = 2;
 }
 


### PR DESCRIPTION
This PR is part of a proof of concept for https://github.com/authzed/spicedb/issues/1903.

It adds a `with_status` boolean field on `WriteRelationshipsRequest`, and creates a new `RelationshipUpdateStatus` type that gets included in `WriteRelationshipsResponse` if `with_status` was true in the request.

There are 4 possible statuses:
- `no_op`: the input operation was a no-op (either a `TOUCH` on a relation that already existed as-is, or a `DELETE` on a relation that didn't exist, I didn't differentiate between them),
- `created`: the input operation led to a relationship being created (from either a `CREATE` or `TOUCH`),
- `deleted`: the input operation led to a relationship being deleted (from a `DELETE`),
- `updated`: the input operation led to a relationship being updated, and the status includes both the old and the new relationships (from a `TOUCH` where caveats differed from what was stored).