### PR TITLE
adds optional revision in LookupPermissionSets

### DIFF
--- a/authzed/api/materialize/v0/watchpermissionsets.proto
+++ b/authzed/api/materialize/v0/watchpermissionsets.proto
@@ -106,6 +106,10 @@ message LookupPermissionSetsRequest {
   // the server will close the stream. If more permission sets are available, the consume should open a new stream
   // providing optional_starting_after_cursor, using the cursor from the last response.
   uint32 limit = 1;
+  // optional_at_revision specifies the client is requesting to lookup PermissionSets at a specific revision. It's
+  // optional, and if not provided, PermissionSets will be looked up at the current revision. The cursor always
+  // takes precedence in defining the revision when present.
+  authzed.api.v1.ZedToken optional_at_revision = 2;
   // optional_starting_after_cursor is used to specify the offset to start streaming permission sets from.
   Cursor optional_starting_after_cursor = 4;
 }


### PR DESCRIPTION
After the introduction of BreakingSchemaChange,
clients will be notified that an incompatible change has happened and that they need rebuild their index. In order to do that, they need to call LookupPermissionSets with the revision at which the breaking event happened.

This introduces an optional revision in LookupPermissionSets to support this use-case.