### PR TITLE
Remove transaction metadata from bulk imports

### DIFF
--- a/authzed/api/v1/experimental_service.proto
+++ b/authzed/api/v1/experimental_service.proto
@@ -228,12 +228,6 @@ message BulkCheckPermissionResponseItem {
 message BulkImportRelationshipsRequest {
   repeated Relationship relationships = 1
       [ (validate.rules).repeated .items.message.required = true ];
-
-
-  // optional_transaction_metadata is an optional field that can be used to store metadata about the transaction.
-  // If specified, this metadata will be supplied in the WatchResponse for the creations associated with
-  // this transaction.
-  google.protobuf.Struct optional_transaction_metadata = 2 [ (validate.rules).message.required = false ];
 }
 
 // BulkImportRelationshipsResponse is returned on successful completion of the

--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -105,7 +105,8 @@ service PermissionsService {
   // performance, the caller should attempt to write relationships in as close
   // to relationship sort order as possible: (resource.object_type,
   // resource.object_id, relation, subject.object.object_type,
-  // subject.object.object_id, subject.optional_relation)
+  // subject.object.object_id, subject.optional_relation). All relationships
+  // written are done so under a single transaction.
   rpc ImportBulkRelationships(stream ImportBulkRelationshipsRequest)
     returns (ImportBulkRelationshipsResponse) {
       option (google.api.http) = {
@@ -673,11 +674,6 @@ message ResolvedSubject {
 message ImportBulkRelationshipsRequest {
   repeated Relationship relationships = 1
       [ (validate.rules).repeated .items.message.required = true ];
-
-  // optional_transaction_metadata is an optional field that can be used to store metadata about the transaction.
-  // If specified, this metadata will be supplied in the WatchResponse for the creations associated with
-  // this transaction.
-  google.protobuf.Struct optional_transaction_metadata = 2 [ (validate.rules).message.required = false ];
 }
 
 // ImportBulkRelationshipsResponse is returned on successful completion of the


### PR DESCRIPTION
The entire bulk import is a single transaction, and there is no message in which we can provide the metadata, so disallow it