### PR TITLE
fixes OpenAPI spec security definitions

### DIFF
--- a/authzed/api/v1/openapi.proto
+++ b/authzed/api/v1/openapi.proto
@@ -32,13 +32,18 @@ option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
 	produces: "application/json";
 	security_definitions: {
 		security: {
-			key: "ApiKeyAuth";
+			key: "bearer";
 			value: {
 				type: TYPE_API_KEY;
 				in: IN_HEADER;
 				name: "Authorization";
+				description: "SpiceDB preshared-key, prefixed by Bearer: Bearer <preshared-key>"
 			}
 		}
 	}
+	security: {
+		security_requirement: {
+			key: "bearer"
+		}
+	}
 };
-


### PR DESCRIPTION
SpiceDB does not use `ApiKeyAuth` authentication, but `Bearer` authentication, where
the type of bearer token is an API Key, as defined by the OpenAPI v3 spec.

However, the OpenAPI v2 Spec, which is the one supported by grpc-gateway,
does not support bearer authentication:
https://swagger.io/docs/specification/v2_0/authentication/authentication/

Still, the grpc-gateway maintainers indicated in
https://github.com/grpc-ecosystem/grpc-gateway/issues/1089
that bearer is actually supported in grpc-gateway generator.

In https://github.com/authzed/authzed-go/pull/255 a user reported
trying to generate Java client code out of the SpiceDB OpenAPI spec,
but had errors because the generated error did not properly provide
the preshared key with the expected `Authorization: Bearer <psk>`
format.

I'm not 100% sure if this is a legit intermediate state
between v2 and v3 we can leverage, but the current generated
client code is clearly broken anyway.

See https://swagger.io/docs/specification/v3_0/authentication/api-keys/
See https://swagger.io/docs/specification/v3_0/authentication/bearer-authentication/

The generated Swagger Spec looks like this

```json
"securityDefinitions": {
    "bearer": {
      "type": "apiKey",
      "description": "SpiceDB preshared-key, prefixed by Bearer: Bearer \u003cpreshared-key\u003e",
      "name": "Authorization",
      "in": "header"
    }
  },
  "security": [
    {
      "bearer": []
    }
  ],
```