### PR TITLE
Update documentation of BulkImportRelationshipsRequest

### DIFF
--- a/authzed/api/v1/experimental_service.proto
+++ b/authzed/api/v1/experimental_service.proto
@@ -222,9 +222,10 @@ message BulkCheckPermissionResponseItem {
 // BulkImportRelationshipsRequest represents one batch of the streaming
 // BulkImportRelationships API. The maximum size is only limited by the backing
 // datastore, and optimal size should be determined by the calling client
-// experimentally. Any relationships within the same request are guaranteed to
-// be written in a single transaction. If any of the relationships already
-// exist, the transaction will fail and no relationships will be written.
+// experimentally. When BulkImport is invoked and receives its first request message,
+// a transaction is opened to import the relationships. All requests sent to the same
+// invocation are executed under this single transaction. If a relationship already
+// exists within the datastore, the entire transaction will fail with an error.
 message BulkImportRelationshipsRequest {
   repeated Relationship relationships = 1
       [ (validate.rules).repeated .items.message.required = true ];

--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -670,7 +670,9 @@ message ResolvedSubject {
 // ImportBulkRelationshipsRequest represents one batch of the streaming
 // ImportBulkRelationships API. The maximum size is only limited by the backing
 // datastore, and optimal size should be determined by the calling client
-// experimentally.
+// experimentally. Any relationships within the same request are guaranteed to
+// be written in a single transaction. If any of the relationships already
+// exist, the transaction will fail and no relationships will be written.
 message ImportBulkRelationshipsRequest {
   repeated Relationship relationships = 1
       [ (validate.rules).repeated .items.message.required = true ];

--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -670,9 +670,10 @@ message ResolvedSubject {
 // ImportBulkRelationshipsRequest represents one batch of the streaming
 // ImportBulkRelationships API. The maximum size is only limited by the backing
 // datastore, and optimal size should be determined by the calling client
-// experimentally. Any relationships within the same request are guaranteed to
-// be written in a single transaction. If any of the relationships already
-// exist, the transaction will fail and no relationships will be written.
+// experimentally. When ImportBulk is invoked and receives its first request message,
+// a transaction is opened to import the relationships. All requests sent to the same
+// invocation are executed under this single transaction. If a relationship already
+// exists within the datastore, the entire transaction will fail with an error.
 message ImportBulkRelationshipsRequest {
   repeated Relationship relationships = 1
       [ (validate.rules).repeated .items.message.required = true ];


### PR DESCRIPTION
## Description
This was noted by a Discord user. The experimental service's version had this, but the permission service's version didn't, which caused confusion and had them asking whether the two versions of the service had any meaningful differences. They don't and this should help clarify that.

## Changes
Copy over the extended documentation

## Testing
Review.