### PR TITLE
Add dotnet to list of triggers

### DIFF
--- a/.github/workflows/release-client-update.yaml
+++ b/.github/workflows/release-client-update.yaml
@@ -37,3 +37,10 @@ jobs:
           repository: "authzed/authzed-java"
           event-type: "api_update"
           client-payload: '{"BUFTAG": "${{ github.ref_name }}"}'
+      - uses: "peter-evans/repository-dispatch@v2"
+        name: "🔵🥅 Update authzed-dotnet"
+        with:
+          token: "${{ secrets.EXTERNAL_REPO_TOKEN }}"
+          repository: "authzed/authzed-dotnet"
+          event-type: "api_update"
+          client-payload: '{"BUFTAG": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Description
I was wondering why `authzed-dotnet` didn't automatically PR when we released API v1.40.0 and then I remembered this action. This should mean that the next API update creates a PR.

## Changes
* Add authzed-dotnet to list of triggers

## Testing
Review.