### PR TITLE
feat: add optional_resource_ids field to RelationshipFilter for bulk …

### DIFF
--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -250,6 +250,19 @@ message RelationshipFilter {
 
   // optional_subject_filter is the optional filter for the subjects of the relationships.
   SubjectFilter optional_subject_filter = 4;
+
+  // optional_resource_ids is the *optional* list of resource IDs for bulk operations.
+  // If specified, optional_resource_id and optional_resource_id_prefix cannot be specified.
+  // This enables efficient bulk queries using SQL IN clauses.
+  repeated string optional_resource_ids = 6 [(validate.rules).repeated = {
+    max_items: 100,
+    items: {
+      string: {
+        pattern: "^([a-zA-Z0-9/_|\\-=+]{1,})?$"
+        max_bytes: 1024
+      }
+    }
+  }];
 }
 
 // SubjectFilter specifies a filter on the subject of a relationship.


### PR DESCRIPTION
## 🚀 Feature: Add Bulk Resource ID Support to RelationshipFilter

### Summary
This PR adds support for bulk operations in `RelationshipFilter` by introducing a new `optional_resource_ids` field that allows filtering relationships by multiple resource IDs in a single request.

### Changes
- **Added** `optional_resource_ids` field (field 6) to `RelationshipFilter` message
- **Type**: `repeated string` for bulk operations
- **Validation**: Up to 100 resource IDs with pattern validation
- **Performance**: Enables efficient SQL IN clause queries

### Technical Details
```protobuf
repeated string optional_resource_ids = 6 [(validate.rules).repeated = {
  max_items: 100,
  items: {
    string: {
      pattern: "^([a-zA-Z0-9/_|\\-=+]{1,})?$"
      max_bytes: 1024
    }
  }
}];
```

### Usage
This field cannot be used simultaneously with `optional_resource_id` or `optional_resource_id_prefix` to maintain clear filtering semantics.

### Breaking Changes
None - this is a purely additive change.

### Testing
- [x] Proto compilation successful
- [x] Validation rules working correctly
- [x] Backward compatibility maintained