### PR TITLE
feat: add DebugInformationV2 and LookupCycleAnnotation for lookup deb…

### DIFF
--- a/authzed/api/v1/debug_v2.proto
+++ b/authzed/api/v1/debug_v2.proto
@@ -9,6 +9,8 @@ option java_package = "com.authzed.api.v1";
 
 // DebugTree represents the structure of a debug tree.
 message DebugTree {
+  string id = 1;
+  repeated DebugTree subtrees = 2;
 }
 
 // DebugScope represents a scope within a debug trace.

--- a/authzed/api/v1/debug_v2.proto
+++ b/authzed/api/v1/debug_v2.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+package authzed.api.v1;
+
+import "google/protobuf/any.proto";
+
+option go_package = "github.com/authzed/authzed-go/proto/authzed/api/v1";
+option java_multiple_files = true;
+option java_package = "com.authzed.api.v1";
+
+// DebugTree represents the structure of a debug tree.
+message DebugTree {
+}
+
+// DebugScope represents a scope within a debug trace.
+message DebugScope {
+  string name = 1;
+  DebugTree tree = 2;
+  map<string, google.protobuf.Any> annotations = 3;
+}
+
+// DebugInformationV2 defines the V2 debug information returned.
+message DebugInformationV2 {
+  map<string, DebugScope> scopes = 1;
+}
+
+// LookupCycleAnnotation represents an annotation for cycle detection in Lookups.
+message LookupCycleAnnotation {
+  string resource_type = 1;
+  string resource_id = 2;
+  string relation = 3;
+  uint32 traversal_count = 4;
+  bool is_cyclic = 5;
+}

--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -3,6 +3,10 @@ package authzed.api.v1;
 
 import "authzed/api/v1/core.proto";
 import "authzed/api/v1/debug.proto";
+<<<<<<< HEAD
+=======
+import "authzed/api/v1/debug_v2.proto";
+>>>>>>> afbbe38 (feat: add DebugInformationV2 and LookupCycleAnnotation for lookup debug traces)
 import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/struct.proto";
@@ -800,6 +804,14 @@ message LookupResourcesResponse {
   // after_result_cursor holds a cursor that can be used to resume the LookupResources stream after this
   // result.
   Cursor after_result_cursor = 5;
+<<<<<<< HEAD
+=======
+
+  // debug_info_v2 is populated only when the x-spicedb-debug request header is set.
+  // Set on the last streamed response message only.
+  // Contains a "lookup_cycles" scope with LookupCycleAnnotation entries.
+  DebugInformationV2 debug_info_v2 = 6;
+>>>>>>> afbbe38 (feat: add DebugInformationV2 and LookupCycleAnnotation for lookup debug traces)
 }
 
 // LookupSubjectsRequest performs a lookup of all subjects of a particular
@@ -931,6 +943,14 @@ message LookupSubjectsResponse {
   // after_result_cursor holds a cursor that can be used to resume the LookupSubjects stream after this
   // result.
   Cursor after_result_cursor = 8;
+<<<<<<< HEAD
+=======
+
+  // debug_info_v2 is populated only when the x-spicedb-debug request header is set.
+  // Set on the last streamed response message only.
+  // Contains a "lookup_cycles" scope with LookupCycleAnnotation entries.
+  DebugInformationV2 debug_info_v2 = 9;
+>>>>>>> afbbe38 (feat: add DebugInformationV2 and LookupCycleAnnotation for lookup debug traces)
 }
 
 // ResolvedSubject is a single subject resolved within LookupSubjects.

--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -3,10 +3,7 @@ package authzed.api.v1;
 
 import "authzed/api/v1/core.proto";
 import "authzed/api/v1/debug.proto";
-<<<<<<< HEAD
-=======
 import "authzed/api/v1/debug_v2.proto";
->>>>>>> afbbe38 (feat: add DebugInformationV2 and LookupCycleAnnotation for lookup debug traces)
 import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/struct.proto";
@@ -804,14 +801,11 @@ message LookupResourcesResponse {
   // after_result_cursor holds a cursor that can be used to resume the LookupResources stream after this
   // result.
   Cursor after_result_cursor = 5;
-<<<<<<< HEAD
-=======
 
   // debug_info_v2 is populated only when the x-spicedb-debug request header is set.
   // Set on the last streamed response message only.
   // Contains a "lookup_cycles" scope with LookupCycleAnnotation entries.
   DebugInformationV2 debug_info_v2 = 6;
->>>>>>> afbbe38 (feat: add DebugInformationV2 and LookupCycleAnnotation for lookup debug traces)
 }
 
 // LookupSubjectsRequest performs a lookup of all subjects of a particular
@@ -943,14 +937,11 @@ message LookupSubjectsResponse {
   // after_result_cursor holds a cursor that can be used to resume the LookupSubjects stream after this
   // result.
   Cursor after_result_cursor = 8;
-<<<<<<< HEAD
-=======
 
   // debug_info_v2 is populated only when the x-spicedb-debug request header is set.
   // Set on the last streamed response message only.
   // Contains a "lookup_cycles" scope with LookupCycleAnnotation entries.
   DebugInformationV2 debug_info_v2 = 9;
->>>>>>> afbbe38 (feat: add DebugInformationV2 and LookupCycleAnnotation for lookup debug traces)
 }
 
 // ResolvedSubject is a single subject resolved within LookupSubjects.


### PR DESCRIPTION
## What
Adds DebugInformationV2 and LookupCycleAnnotation for lookup debug tracing.

## Why
Enables structured debug output for lookup traversal (e.g. cycle detection),
aligned with DebugInformation V2 design discussed in #163.

## Changes
- Added debug_v2.proto with:
  - DebugTree
  - DebugScope
  - DebugInformationV2
  - LookupCycleAnnotation
- Added debug_info_v2 field to:
  - LookupResourcesResponse
  - LookupSubjectsResponse

## Example
{
  "debug_info_v2": {
    "scopes": {
      "lookup_cycles": {
        "annotations": {
          "node1": {
            "@type": "type.googleapis.com/authzed.api.v1.LookupCycleAnnotation",
            "traversal_count": 3,
            "is_cyclic": true
          }
        }
      }
    }
  }
}

## Notes
- Backward compatible
- Populated only when debug header is set
- SpiceDB PR will handle population

Refs: #163