### PR TITLE
api(materialize/v0): add at_revision zedtoken to DownloadPermissionSetsResponse

### DIFF
--- a/authzed/api/materialize/v0/watchpermissionsets.proto
+++ b/authzed/api/materialize/v0/watchpermissionsets.proto
@@ -217,4 +217,10 @@ message DownloadPermissionSetsResponse {
 
   // timestamp represents the time associated with the returned data revision.
   google.protobuf.Timestamp timestamp = 2;
+
+  // at_revision is the snapshot revision the returned files were produced at,
+  // encoded as a ZedToken. Consumers should pass this token to
+  // WatchPermissionSets as optional_starting_after to resume the stream
+  // immediately after the snapshot without leaving gaps in event history.
+  authzed.api.v1.ZedToken at_revision = 3;
 }

--- a/docs/apidocs.swagger.json
+++ b/docs/apidocs.swagger.json
@@ -1642,6 +1642,10 @@
           "type": "string",
           "format": "date-time",
           "description": "timestamp represents the time associated with the returned data revision."
+        },
+        "atRevision": {
+          "$ref": "#/definitions/ZedToken",
+          "description": "at_revision is the snapshot revision the returned files were produced at,\nencoded as a ZedToken. Consumers should pass this token to\nWatchPermissionSets as optional_starting_after to resume the stream\nimmediately after the snapshot without leaving gaps in event history."
         }
       }
     },


### PR DESCRIPTION
## Description

`DownloadPermissionSetsResponse` currently exposes the snapshot revision only as
a `google.protobuf.Timestamp`. Customers who want to resume from a download by
calling `WatchPermissionSets` have no way to obtain a `ZedToken` for the
snapshot, so they either skip the cursor (leaving a gap between the snapshot
and the WPS stream) or parse the revision out of `metadata.json` and re-encode
it themselves — neither is something we want to expose as a contract.

This PR adds an `at_revision` `ZedToken` field to the response so that the
snapshot revision can be passed directly to `WatchPermissionSets` as
`optional_starting_after`, picking up the stream immediately after the
snapshot with no event-history gap.

## Changes

- Add `authzed.api.v1.ZedToken at_revision = 3;` to
  `DownloadPermissionSetsResponse` in
  `authzed/api/materialize/v0/watchpermissionsets.proto`.
- Regenerate `docs/apidocs.swagger.json`.

Field name `at_revision` matches the existing naming convention used by
`PermissionSetChange.at_revision` and mirrors the request's
`optional_at_revision`.

## Testing

- `buf build` passes.
- `buf breaking --against '.git#branch=main'` passes — additive, non-breaking
  change (new field, new tag number).