### PR TITLE
Document that lookup APIs do not guarantee unique results

### DIFF
--- a/authzed/api/v1/permission_service.proto
+++ b/authzed/api/v1/permission_service.proto
@@ -96,6 +96,11 @@ service PermissionsService {
 
   // LookupResources returns all the resources of a given type that a subject
   // can access whether via a computed permission or relation membership.
+  //
+  // Results are streamed and **not guaranteed to be unique**: the same resource
+  // may be returned more than once (for example via caveated/conditional
+  // results, or when a limit is set), possibly with differing permissionship.
+  // Callers that require uniqueness should deduplicate results.
   rpc LookupResources(LookupResourcesRequest) returns (stream LookupResourcesResponse) {
     option (google.api.http) = {
       post: "/v1/permissions/resources"
@@ -108,6 +113,10 @@ service PermissionsService {
 
   // LookupSubjects returns all the subjects of a given type that
   // have access whether via a computed permission or relation membership.
+  //
+  // Results are streamed and **not guaranteed to be unique**: the same subject
+  // may be returned more than once, possibly with differing permissionship.
+  // Callers that require uniqueness should deduplicate results.
   rpc LookupSubjects(LookupSubjectsRequest) returns (stream LookupSubjectsResponse) {
     option (google.api.http) = {
       post: "/v1/permissions/subjects"

--- a/docs/apidocs.swagger.json
+++ b/docs/apidocs.swagger.json
@@ -472,6 +472,7 @@
     "/v1/permissions/resources": {
       "post": {
         "summary": "LookupResources returns all the resources of a given type that a subject\ncan access whether via a computed permission or relation membership.",
+        "description": "Results are streamed and **not guaranteed to be unique**: the same resource\nmay be returned more than once (for example via caveated/conditional\nresults, or when a limit is set), possibly with differing permissionship.\nCallers that require uniqueness should deduplicate results.",
         "operationId": "PermissionsService_LookupResources",
         "responses": {
           "200": {
@@ -515,6 +516,7 @@
     "/v1/permissions/subjects": {
       "post": {
         "summary": "LookupSubjects returns all the subjects of a given type that\nhave access whether via a computed permission or relation membership.",
+        "description": "Results are streamed and **not guaranteed to be unique**: the same subject\nmay be returned more than once, possibly with differing permissionship.\nCallers that require uniqueness should deduplicate results.",
         "operationId": "PermissionsService_LookupSubjects",
         "responses": {
           "200": {


### PR DESCRIPTION
Fixes #170.

Documents that `LookupResources` and `LookupSubjects` do not guarantee unique
results, so callers that need uniqueness must deduplicate themselves.