### PR TITLE
Trigger prototype client regeneration on API changes

### DIFF
--- a/.github/workflows/clients-prototype-update.yaml
+++ b/.github/workflows/clients-prototype-update.yaml
@@ -1,0 +1,76 @@
+---
+name: "Client updates for the prototype monorepo"
+# Chained off Lint and Release rather than triggered directly on push/release,
+# because those workflows are what push the module to the BSR. Dispatching
+# straight from `on: push` races that upload, and BUFTAG pinning would then fail
+# on a ref that does not exist yet.
+on:
+  workflow_run:
+    workflows: ["Lint", "Release"]
+    types: ["completed"]
+permissions:
+  contents: "read"
+jobs:
+  dispatch:
+    name: "Trigger prototype client regeneration"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 10
+    if: "${{ github.event.workflow_run.conclusion == 'success' }}"
+    steps:
+      # `on: workflow_run` supports no paths filter, so the proto-relevance check
+      # happens here against the triggering commit.
+      - name: "Decide whether this commit warrants regeneration"
+        id: "decide"
+        uses: "actions/github-script@v9"
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const isRelease = run.name === 'Release';
+
+            // A release always regenerates; the tag is the pin.
+            if (isRelease) {
+              const tag = run.head_branch;
+              if (!tag || !tag.startsWith('v')) {
+                core.info(`Release run head_branch '${tag}' is not a version tag; skipping.`);
+                core.setOutput('go', 'false');
+                return;
+              }
+              core.setOutput('go', 'true');
+              core.setOutput('event', 'api_release_update');
+              core.setOutput('buftag', tag);
+              return;
+            }
+
+            if (run.head_branch !== 'main') {
+              core.info(`Lint run was for '${run.head_branch}', not main; skipping.`);
+              core.setOutput('go', 'false');
+              return;
+            }
+
+            const commit = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: run.head_sha,
+            });
+            const files = (commit.data.files || []).map(f => f.filename);
+            // docs/ is buf-generated swagger, downstream of the protos -- a change
+            // there alone means nothing new for the clients.
+            const relevant = files.some(f =>
+              f.startsWith('authzed/') || f === 'buf.yaml' || f === 'buf.lock');
+            if (!relevant) {
+              core.info(`No proto-relevant changes in ${run.head_sha}; skipping.`);
+              core.setOutput('go', 'false');
+              return;
+            }
+            core.setOutput('go', 'true');
+            core.setOutput('event', 'api_main_update');
+            core.setOutput('buftag', run.head_sha);
+
+      - uses: "peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0" # v3.0.0
+        name: "🧪 Update spicedb-clients-prototype"
+        if: "${{ steps.decide.outputs.go == 'true' }}"
+        with:
+          token: "${{ secrets.EXTERNAL_REPO_TOKEN }}"
+          repository: "authzed/spicedb-clients-prototype"
+          event-type: "${{ steps.decide.outputs.event }}"
+          client-payload: '{"BUFTAG": "${{ steps.decide.outputs.buftag }}"}'

--- a/.github/workflows/clients-prototype-update.yaml
+++ b/.github/workflows/clients-prototype-update.yaml
@@ -15,7 +15,19 @@ jobs:
     name: "Trigger prototype client regeneration"
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
-    if: "${{ github.event.workflow_run.conclusion == 'success' }}"
+    # Both extra clauses are load-bearing, not belt-and-braces. Lint runs on
+    # `pull_request` for every branch, so a fork PR produces a completed Lint
+    # run and fires workflow_run here -- in the BASE repo, with secrets. The
+    # script's `head_branch !== 'main'` check does not stop it: for a fork PR
+    # head_branch is the FORK's branch name, attacker-chosen and `main` by
+    # default on a fresh fork. Requiring `event == 'push'` and an in-repository
+    # head repository is what actually makes the trigger fork-unreachable. Both
+    # intended paths -- Lint on a push to main, Release on a tag push -- are
+    # push events originating here, so nothing legitimate is lost.
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event == 'push'
+          && github.event.workflow_run.head_repository.full_name == github.repository }}
     steps:
       # `on: workflow_run` supports no paths filter, so the proto-relevance check
       # happens here against the triggering commit.

--- a/.github/workflows/clients-prototype-update.yaml
+++ b/.github/workflows/clients-prototype-update.yaml
@@ -52,11 +52,26 @@ jobs:
               repo: context.repo.repo,
               ref: run.head_sha,
             });
-            const files = (commit.data.files || []).map(f => f.filename);
+            // The Get-a-commit API truncates `files` at 300 entries and omits the
+            // field entirely for very large commits. When we cannot see the whole
+            // list we cannot prove a commit is irrelevant, so we dispatch anyway.
+            // A needless regeneration finds no proto diff and opens no PR; a missed
+            // one leaves the clients silently stale, which is the exact failure this
+            // workflow exists to prevent. Fail open, and say so in the log.
+            const files = commit.data.files;
+            const truncated = !files || files.length >= 300;
+            if (truncated) {
+              core.info(
+                `Cannot enumerate all files for ${run.head_sha} ` +
+                `(${files ? files.length + ' files, API caps at 300' : 'file list omitted'}); ` +
+                `dispatching rather than risk a silent skip.`);
+            }
             // docs/ is buf-generated swagger, downstream of the protos -- a change
             // there alone means nothing new for the clients.
-            const relevant = files.some(f =>
-              f.startsWith('authzed/') || f === 'buf.yaml' || f === 'buf.lock');
+            const relevant = truncated || files.some(f =>
+              f.filename.startsWith('authzed/') ||
+              f.filename === 'buf.yaml' ||
+              f.filename === 'buf.lock');
             if (!relevant) {
               core.info(`No proto-relevant changes in ${run.head_sha}; skipping.`);
               core.setOutput('go', 'false');
@@ -66,7 +81,7 @@ jobs:
             core.setOutput('event', 'api_main_update');
             core.setOutput('buftag', run.head_sha);
 
-      - uses: "peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0" # v3.0.0
+      - uses: "peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0"  # v3.0.0
         name: "🧪 Update spicedb-clients-prototype"
         if: "${{ steps.decide.outputs.go == 'true' }}"
         with:


### PR DESCRIPTION
**Draft — merge last.** Part 3 of 3 wiring automatic client regeneration into `authzed/spicedb-clients-prototype` (see that repo's PRs #58 and #59). Nothing here affects this repo's own builds; it only fires a `repository_dispatch` outward.

Deliberately a **new file** — `manual-client-update.yaml` and `release-client-update.yaml` are untouched, so the legacy five-client pipeline is unaffected and this prototype wiring is one `git rm` away if it's ever abandoned.

## What it does

Chains off `Lint` and `Release` completing successfully, then dispatches to the prototype repo with a `BUFTAG` pinning the exact upstream revision:

- `api_main_update` — `BUFTAG` is the api git SHA
- `api_release_update` — `BUFTAG` is the release tag

## Why chained off `Lint` rather than triggered on push

`Lint` is what pushes the module to the BSR. Dispatching straight from `on: push` races that upload, and the receiving side pins to an exact BSR ref — so losing the race means the ref doesn't exist yet. Chaining on successful completion removes the race and also ensures we never regenerate from a commit whose `buf` breaking-change check failed.

Two related details that are deliberate and look wrong at a glance:

- **`workflow_run.head_sha`, not `github.sha`.** Under `workflow_run`, `github.sha` resolves to the default-branch head, not the triggering commit.
- **Relevance is checked in the job, not declaratively.** `on: workflow_run` supports no `paths:` filter, so the proto-relevance check uses the compare API. `docs/` is excluded because it holds buf-generated swagger, downstream of the protos.

## Security: the trigger must reject fork-originated runs

This is the part worth reviewing closely. `lint.yaml` runs on `pull_request` for **all** branches, so a fork PR produces a completed `Lint` run — and `workflow_run` fires for those in the base repo **with secrets**. Filtering on `head_branch !== 'main'` does not stop it, because for a fork PR `head_branch` is the *fork's* branch name: attacker-chosen, and `main` by default on a fresh fork.

Without a guard, an external contributor could cause the prototype repo to spin up an 8-core runner and materialize a Claude credential into a job, repeatedly. The job therefore also requires:

```yaml
github.event.workflow_run.event == 'push'
&& github.event.workflow_run.head_repository.full_name == github.repository
```

Both intended paths — Lint on a push to main, Release on a tag push — are same-repo push events, so nothing legitimate is lost.

## Fails open on an unenumerable commit

GitHub's Get-a-commit API caps `files` at 300 entries and omits the field entirely for very large commits. Treating that as "no relevant files" would skip the dispatch with a green job and no error anywhere — leaving clients silently stale, the exact failure this design exists to prevent. When the list can't be fully enumerated the workflow dispatches anyway and logs why: a needless regeneration finds no proto diff and opens no PR, while a missed one is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
